### PR TITLE
Update kcptun.sh

### DIFF
--- a/kcptun/kcptun.sh
+++ b/kcptun/kcptun.sh
@@ -1945,7 +1945,7 @@ set_hidden_parameters() {
 				continue
 			fi
 
-			sockbuf=$(expr $input * 1024 * 1024)
+			sockbuf=$(expr $input \* 1024 \* 1024)
 		fi
 		break
 	done
@@ -1970,7 +1970,7 @@ set_hidden_parameters() {
 				continue
 			fi
 
-			smuxbuf=$(expr $input * 1024 * 1024)
+			smuxbuf=$(expr $input \* 1024 \* 1024)
 		fi
 		break
 	done


### PR DESCRIPTION
socket_buf的 expr计算，需要使用：
```
\*
```
  来做乘法，目前是：
```
*
```
在设定缓存大小的时候输入数字后，就会触发bug

报 expr错误